### PR TITLE
add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ pfmodelclasses | --Kafka key builder-- | --KafkaKeyRelationship--
 ## Prerequisites
 requirements.txt
 ```txt
-requests
-boto3
-pyyaml
-kafka-python
 ibm-pathfinder-sdk
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,12 @@ version = "0.0.0"
 authors = [
   { name="IBM", email="wci01@zurich.ibm.com" },
 ]
+dependencies = [
+  "requests",
+  "boto3",
+  "pyyaml",
+  "kafka-python"
+]
 description = "Parthfinder connector lib package"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Signed-off-by: Peter Urbanetz <URB@zurich.ibm.com>

dependencies will be loaded on project with 
`pip install ibm-pathfinder-sdk` on release > 0.1.4 